### PR TITLE
feat: add ability to build query

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save react-lunr
 ### `useLunr`
 
 ```js
-useLunr(query?: string, index?: lunr.Index | JSON | string, store: object | string) => object[]
+useLunr(query?: string | lunr.Index.QueryBuilder, index?: lunr.Index | JSON | string, store: object | string) => object[]
 ```
 
 The `useLunr` [hook][hooks] takes your search query, index, and store and
@@ -27,11 +27,11 @@ searching.
 
 #### Parameters
 
-| Name        | Type                           | Description                                                                                                                           |
-| ----------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| **`query`** | `string`                       | The search query. As this value updates, the return value will be updated.                                                            |
-| **`index`** | `lunr.Index \| JSON \| string` | The Lunr index. This can be an instance of a Lunr index or one that has been exported via `index.toJSON` or `JSON.stringify`.         |
-| **`store`** | `JSON \| string`               | Object mapping a result `ref` to an object of data. This can be an object or an object that has been exported via `JSON.stringified`. |
+| Name        | Type                                  | Description                                                                                                                           |
+| ----------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **`query`** | `string` \| `lunr.Index.QueryBuilder` | The search query. As this value updates, the return value will be updated. This can be a string or a query builder.                   |
+| **`index`** | `lunr.Index \| JSON \| string`        | The Lunr index. This can be an instance of a Lunr index or one that has been exported via `index.toJSON` or `JSON.stringify`.         |
+| **`store`** | `JSON \| string`                      | Object mapping a result `ref` to an object of data. This can be an object or an object that has been exported via `JSON.stringified`. |
 
 If `store` is not provided, the raw results data from Lunr will be returned
 instead. This includes the `ref` used when creating the index.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import invariant from 'tiny-invariant'
 type Store<T> = Record<string | number | symbol, T>
 
 export const useLunr = <T = unknown>(
-  query?: string,
+  query?: string | Index.QueryBuilder,
   rawIndex?: Index | object | string,
   rawStore?: Store<T> | string,
 ) => {
@@ -37,7 +37,8 @@ export const useLunr = <T = unknown>(
   return useMemo(() => {
     if (!query || !index) return []
 
-    const results = index.search(query)
+    const results =
+      typeof query === 'string' ? index.search(query) : index.query(query)
 
     if (store) return results.map(({ ref }) => store[ref])
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -103,4 +103,12 @@ describe('useLunr', () => {
     const { result } = renderHook(() => useLunr(documents[0].name, 0 as any))
     expect(result.error.message).toMatch(/invalid index provided/i)
   })
+
+  test.only('returns results if builded query has matches', () => {
+    const queryBuilder: lunr.Index.QueryBuilder = (q) => {
+      q.term(documents[0].name.toLowerCase(), {})
+    }
+    const { result } = renderHook(() => useLunr(queryBuilder, index, store))
+    expect(result.current).toEqual([documents[0]])
+  })
 })


### PR DESCRIPTION
Lunr supports a query builder that is useful for more complex or programatically created search queries.

See https://lunrjs.com/docs/lunr.Index.html#query

This PR adds ability to pass a query builder to the hook.

This is a backwards compatible change.